### PR TITLE
Implement YARA rule scanning

### DIFF
--- a/custos.toml
+++ b/custos.toml
@@ -1,3 +1,4 @@
 thread_count = 4
 database_location = "./db/custos.sqlite"
+yara_rule_directory = "./rules"
 scan_directories = ["/etc/**/*"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub thread_count: usize,
     pub database_location: String,
     pub scan_directories: Vec<String>,
+    pub yara_rule_directory: String,
 }
 
 fn init_config() -> Config {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -1,9 +1,9 @@
 use std::sync::atomic::AtomicU16;
 
 use tokio::time::Instant;
-use tracing::{debug, warn};
+use tracing::debug;
 
-use crate::strategies::{self, FileStatus, ScanStrategyResult};
+use crate::strategies::{FileStatus, ScanStrategyResult};
 
 static COORDINATOR_ID: AtomicU16 = AtomicU16::new(0);
 
@@ -26,10 +26,18 @@ impl<'a> ScanCoordinator<'a> {
             id: COORDINATOR_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             channel,
             paths,
-            scan_strategies: vec![Box::new(strategies::SHA256FileScanStrategy::new())],
+            scan_strategies: Vec::new(),
             process_strategies: Vec::new(),
             update,
         }
+    }
+
+    pub fn add_scan_strategy(&mut self, strategy: Box<dyn crate::strategies::ScanStrategy>) {
+        self.scan_strategies.push(strategy);
+    }
+
+    pub fn add_process_strategy(&mut self, strategy: Box<dyn crate::strategies::ProcessStrategy>) {
+        self.process_strategies.push(strategy);
     }
 
     pub fn run(&self) {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -3,16 +3,16 @@ use std::sync::atomic::AtomicU16;
 use tokio::time::Instant;
 use tracing::debug;
 
-use crate::strategies::{FileStatus, ScanStrategyResult};
+use crate::strategies::{FileStatus, StrategyResult};
 
 static COORDINATOR_ID: AtomicU16 = AtomicU16::new(0);
 
 pub struct ScanCoordinator<'a> {
     id: u16,
-    channel: crossbeam::channel::Sender<ScanStrategyResult>,
+    channel: crossbeam::channel::Sender<StrategyResult>,
     pub paths: &'a [String],
-    pub scan_strategies: Vec<Box<dyn crate::strategies::ScanStrategy>>,
-    pub process_strategies: Vec<Box<dyn crate::strategies::ProcessStrategy>>,
+    scan_strategies: Vec<Box<dyn crate::strategies::ScanStrategy>>,
+    process_strategies: Vec<Box<dyn crate::strategies::ProcessStrategy>>,
     pub update: bool,
 }
 
@@ -20,7 +20,7 @@ impl<'a> ScanCoordinator<'a> {
     pub fn new(
         update: bool,
         paths: &'a [String],
-        channel: crossbeam::channel::Sender<ScanStrategyResult>,
+        channel: crossbeam::channel::Sender<StrategyResult>,
     ) -> ScanCoordinator {
         ScanCoordinator {
             id: COORDINATOR_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
@@ -69,7 +69,17 @@ impl<'a> ScanCoordinator<'a> {
                         strategy.update(path, &data);
                     } else {
                         let result = strategy.process(path, &data);
-                        let _ = self.channel.send(ScanStrategyResult {
+                        for process_strategy in &self.process_strategies {
+                            if let Some(process_result) =
+                                process_strategy.process(&result, path, &data)
+                            {
+                                let _ = self.channel.send(StrategyResult {
+                                    strategy: process_strategy.get_name().to_string(),
+                                    result: process_result,
+                                });
+                            }
+                        }
+                        let _ = self.channel.send(StrategyResult {
                             strategy: strategy.get_name().to_string(),
                             result,
                         });
@@ -77,7 +87,7 @@ impl<'a> ScanCoordinator<'a> {
                 }
             }
             Err(e) => {
-                let _ = self.channel.send(ScanStrategyResult {
+                let _ = self.channel.send(StrategyResult {
                     strategy: String::from("Coordinator"),
                     result: FileStatus::ReadFailed(path.to_str().unwrap().to_owned(), e),
                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,8 @@ async fn main() {
         for chunk in chunks {
             let s = sender.clone();
             workers.push(tokio::spawn(async move {
-                let scanner = coordinator::ScanCoordinator::new(update, &chunk, s);
+                let mut scanner = coordinator::ScanCoordinator::new(update, &chunk, s);
+                scanner.add_scan_strategy(Box::new(strategies::SHA256FileScanStrategy::new()));
                 scanner.run();
             }));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ async fn main() {
             workers.push(tokio::spawn(async move {
                 let mut scanner = coordinator::ScanCoordinator::new(update, &chunk, s);
                 scanner.add_scan_strategy(Box::new(strategies::SHA256FileScanStrategy::new()));
+                scanner.add_process_strategy(Box::new(strategies::YaraFileScanStrategy::new(
+                    config.yara_rule_directory.clone(),
+                )));
                 scanner.run();
             }));
         }

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -6,5 +6,5 @@ mod report_manager;
 pub mod terminal_reporter;
 
 pub(crate) trait Reporter {
-    fn report(&self, result: &strategies::ScanStrategyResult);
+    fn report(&self, result: &strategies::StrategyResult);
 }

--- a/src/reports/report_manager.rs
+++ b/src/reports/report_manager.rs
@@ -5,14 +5,12 @@ use crate::strategies;
 use super::Reporter;
 
 pub struct ReportManager {
-    channel: crossbeam::channel::Receiver<strategies::ScanStrategyResult>,
+    channel: crossbeam::channel::Receiver<strategies::StrategyResult>,
     reporters: Vec<Box<dyn Reporter>>,
 }
 
 impl ReportManager {
-    pub fn new(
-        channel: crossbeam::channel::Receiver<strategies::ScanStrategyResult>,
-    ) -> ReportManager {
+    pub fn new(channel: crossbeam::channel::Receiver<strategies::StrategyResult>) -> ReportManager {
         ReportManager {
             channel,
             reporters: Vec::new(),

--- a/src/reports/terminal_reporter.rs
+++ b/src/reports/terminal_reporter.rs
@@ -13,7 +13,7 @@ impl TerminalReporter {
 }
 
 impl super::Reporter for TerminalReporter {
-    fn report(&self, result: &crate::strategies::ScanStrategyResult) {
+    fn report(&self, result: &crate::strategies::StrategyResult) {
         match &result.result {
             FileStatus::OK(path) => trace!("file passed: {:?}", path),
             FileStatus::NewFile(path) => {

--- a/src/strategies/hash_strategy.rs
+++ b/src/strategies/hash_strategy.rs
@@ -1,5 +1,5 @@
 use sha2::{Digest, Sha256};
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 
 use crate::{db, strategies::FileStatus};
 

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -13,7 +13,12 @@ pub trait ScanStrategy {
 }
 
 pub trait ProcessStrategy {
-    fn process(&self, status: FileStatus, path: &std::path::Path, data: &[u8]) -> FileStatus;
+    fn process(
+        &self,
+        status: &FileStatus,
+        path: &std::path::Path,
+        data: &[u8],
+    ) -> Option<FileStatus>;
     fn get_name(&self) -> &str;
 }
 
@@ -27,7 +32,7 @@ pub enum FileStatus {
 }
 
 #[derive(Debug)]
-pub struct ScanStrategyResult {
+pub struct StrategyResult {
     pub strategy: String,
     pub result: FileStatus,
 }

--- a/src/strategies/yara_strategy.rs
+++ b/src/strategies/yara_strategy.rs
@@ -1,12 +1,21 @@
+use tracing::warn;
+
 use super::ProcessStrategy;
 
 pub struct YaraFileScanStrategy {
-    rule_directory: String,
+   rules: Option<yara::Rules>
 }
 
 impl YaraFileScanStrategy {
     pub fn new(rule_directory: String) -> YaraFileScanStrategy {
-        YaraFileScanStrategy { rule_directory }
+        let mut compiler = yara::Compiler::new().unwrap();
+        let paths = std::fs::read_dir(rule_directory).unwrap();
+        for path in paths {
+            compiler = compiler.add_rules_file(path.unwrap().path()).expect("add yara rule file");
+        }
+        YaraFileScanStrategy { 
+            rules: Some(compiler.compile_rules().expect("yara rule compilation")),
+        }
     }
 }
 


### PR DESCRIPTION
The initial implementation of YARA rule scanning. This allows a user to specify a rule directory, and any files discovered by the scanning strategy will be processed.